### PR TITLE
pkg/v1alpha1: Fix broken test

### DIFF
--- a/pkg/v1alpha1/api/api_test.go
+++ b/pkg/v1alpha1/api/api_test.go
@@ -43,7 +43,7 @@ func TestRoutes(t *testing.T) {
 		statusCode int
 	}{
 		{name: "EventsRead", httpMethod: http.MethodGet, url: "/v1alpha1/events/" + eventID, statusCode: http.StatusOK},
-		{name: "EventsReadAll", httpMethod: http.MethodGet, url: "/v1alpha1/events", statusCode: http.StatusOK},
+		{name: "EventsReadAll", httpMethod: http.MethodGet, url: "/v1alpha1/events?meta.type=EiffelArtifactCreatedEvent", statusCode: http.StatusOK},
 		{name: "SearchRead", httpMethod: http.MethodGet, url: "/v1alpha1/search/" + eventID, statusCode: http.StatusNotImplemented},
 		{name: "SearchUpstreamDownstream", httpMethod: http.MethodPost, url: "/v1alpha1/search/" + eventID, statusCode: http.StatusNotImplemented},
 	}
@@ -62,7 +62,7 @@ func TestRoutes(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			ctx := context.Background()
-			app, err := application.Get(ctx, mockCfg, &log.Entry{})
+			app, err := application.Get(ctx, mockCfg, log.NewEntry(log.New()))
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
### Applicable Issues
Fixes #20 

### Description of the Change
The EventsReadAll testcase in api_test.go had two problems that have been addressed to produce a passing test:

- The PEG parser doesn't accept empty queries so we ended up in an error handler conditional.
- On top of that, the test passed an incorrectly initialized logger to the SUT which resulted in a SIGSEGV (because the *log.Entry used to log the bad query had a nil *log.Logger).

The /events endpoint should accept an empty query but let's address that separately (see #21).

### Alternate Designs
We could've fixed the problem reported in #21 right away instead of working around that problem by adding a simple condition to the query, but in the interest of getting passing tests ASAP we're doing that separately.

### Benefits
Passing tests.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
