### PR TITLE
Makefile: General cleanup, revamped build tool installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,73 @@
+# Install tools locally instead of in $HOME/go/bin.
+export GOBIN := $(CURDIR)/bin
+export PATH := $(GOBIN):$(PATH)
+
 export RELEASE_VERSION ?= $(shell git describe --always)
 export DOCKER_REGISTRY ?= registry.nordix.org/eiffel
 export DEPLOY ?= goer
 
+COMPILEDAEMON = $(GOBIN)/CompileDaemon
+GOER = $(GOBIN)/goer
+GOVVV = $(GOBIN)/govvv
+MOCKGEN = $(GOBIN)/mockgen
+PIGEON = $(GOBIN)/pigeon
+
+.PHONY: all
 all: test build start
-gen:
+
+.PHONY: gen-deps
+gen-deps: $(MOCKGEN) $(PIGEON)
+
+.PHONY: gen
+gen: gen-deps
 	go generate ./...
-build: gen
-	go get github.com/ahmetb/govvv@v0.3.0
-	govvv build -o bin/goer ./cmd/goer
+
+.PHONY: build
+build: gen $(GOVVV)
+	$(GOVVV) build -o $(GOER) ./cmd/goer
+
+.PHONY: clean
 clean:
-	rm ./bin/* || true
+	$(RM) $(GOER) $(GOVVV) $(MOCKGEN) $(PIGEON)
 	docker-compose --project-directory . -f deploy/$(DEPLOY)/docker-compose.yml rm || true
 	docker volume rm goer-volume || true
+
+.PHONY: test
 test: gen
 	go test -cover -timeout 30s -race $(shell go list ./... | grep -v test) 
 
 # Start a development docker with a database that restarts on file changes.
-start:
+.PHONY: start
+start: $(COMPILEDAEMON) gen-deps
 	docker-compose --project-directory . -f deploy/$(DEPLOY)/docker-compose.yml up
+
+.PHONY: stop
 stop:
 	docker-compose --project-directory . -f deploy/$(DEPLOY)/docker-compose.yml down
 
 # Build a docker using the production Dockerfile
+.PHONY: docker
 docker:
 	docker build -t $(DOCKER_REGISTRY)/$(DEPLOY):$(RELEASE_VERSION) -f ./deploy/$(DEPLOY)/Dockerfile .
+
+.PHONY: push
 push:
 	docker push $(DOCKER_REGISTRY)/$(DEPLOY):$(RELEASE_VERSION)
+
+# Build dependencies
+
+$(COMPILEDAEMON):
+	mkdir -p $(dir $@)
+	go install github.com/githubnemo/CompileDaemon@v1.3.0
+
+$(GOVVV):
+	mkdir -p $(dir $@)
+	go install github.com/ahmetb/govvv@v0.3.0
+
+$(MOCKGEN):
+	mkdir -p $(dir $@)
+	go install github.com/golang/mock/mockgen@v1.6.0
+
+$(PIGEON):
+	mkdir -p $(dir $@)
+	go install github.com/mna/pigeon@v1.1.0

--- a/deploy/goer/Dockerfile.dev
+++ b/deploy/goer/Dockerfile.dev
@@ -1,10 +1,6 @@
 FROM golang:1.16.3
 WORKDIR /app
 
-RUN go install github.com/golang/mock/mockgen@v1.6.0
-RUN go install github.com/githubnemo/CompileDaemon@v1.3.0
-RUN go install github.com/mna/pigeon@v1.1.0
-
 COPY ./go.mod ./go.sum ./
 RUN go mod download
 COPY . .

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,6 +3,8 @@
 set -e
 
 # Setup requirements
+export GOBIN=$(pwd)/bin
+export PATH=$GOBIN:$PATH
 make gen
 sleep 1
-/go/bin/CompileDaemon --build="go build -o bin/goer ./cmd/goer" --exclude-dir=".git" --exclude-dir="**/**/test" --exclude-dir="**/**/gomock*" --command=./bin/goer -verbose
+CompileDaemon --build="go build -o bin/goer ./cmd/goer" --exclude-dir=".git" --exclude-dir="**/**/test" --exclude-dir="**/**/gomock*" --command=./bin/goer -verbose


### PR DESCRIPTION
### Applicable Issues
Fixes #6 

### Description of the Change
The makefile rules have been revamped to avoid unnecessary rebuilds of various target files and generally conform to best practices:

- Phony rules are marked as such with .PHONY.
- Build tool dependencies each get their own rule that installs the tool in question, and rules that need these tools have their
dependencies set accordingly.
- GOBIN is changed to $(pwd)/bin so we won't trample on (or blindly use) globally installed tools.
- The clean goal now also removes downloaded tools.

Additionally, the tool installation for Dockerfile.dev has been rewritten to use the tools from $GOBIN since we're mounting it from the host anyway, i.e. there's no reason to install the tools again from the dockerfile. This is especially true since docker-compose by default won't rebuild the image, i.e. if you change the versions of any of the tools that change wouldn't get picked up unless you explicitly force docker-compose to build the image even if it exists.

### Alternate Designs
None.

### Benefits
Proper tool dependencies in the makefile. No unnecessary reinstallations, i.e. quicker turnaround time for common operations.

### Possible Drawbacks
Now that we're not reinstalling the tools all the time we won't reinstall them either if the version has been updated. The user must remember to run `make clean` first.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
