### PR TITLE
Use github.com/stretchr/testify/assert in all tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/snowzach/rotatefilehook v0.0.0-20180327172521-2f64f265f58c
+	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.7.1
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,10 @@ github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
@@ -76,8 +78,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
@@ -125,6 +128,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,8 @@ package config
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Test that it is possible to get a Cfg from Get with values taken from environment variables.
@@ -32,21 +34,11 @@ func TestGet(t *testing.T) {
 	os.Setenv("LOG_FILE_PATH", logFilePath)
 
 	cfg, ok := Get().(*Cfg)
-	if !ok {
-		t.Error("cfg returned from get is not a config interface")
-	}
-	if cfg.connectionString != connectionString {
-		t.Error("connection string not set to environment variable CONNECTION_STRING")
-	}
-	if cfg.apiPort != port {
-		t.Error("api port not set to environment variable API_PORT")
-	}
-	if cfg.logLevel != logLevel {
-		t.Error("log level not set to environment variable LOGLEVEL")
-	}
-	if cfg.logFilePath != logFilePath {
-		t.Error("log file path not set to environment variable LOG_FILE_PATH")
-	}
+	assert.Truef(t, ok, "cfg returned from get is not a config interface")
+	assert.Equal(t, connectionString, cfg.connectionString)
+	assert.Equal(t, port, cfg.apiPort)
+	assert.Equal(t, logLevel, cfg.logLevel)
+	assert.Equal(t, logFilePath, cfg.logFilePath)
 }
 
 type getter func() string
@@ -74,9 +66,7 @@ func TestGetters(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			if testCase.function() != testCase.value {
-				t.Errorf("function does not return %q from Cfg struct", testCase.value)
-			}
+			assert.Equal(t, testCase.value, testCase.function())
 		})
 	}
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eiffel-community/eiffel-goer/test/mock_drivers"
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGet(t *testing.T) {
@@ -41,23 +42,17 @@ func TestGet(t *testing.T) {
 	mockDriver.EXPECT().Get(gomock.Any(), gomock.Any(), entry).Return(mockDB, nil)
 	ctx := context.Background()
 	_, err := database.Get(ctx, url, entry)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestGetUnknownScheme(t *testing.T) {
 	ctx := context.Background()
 	_, err := database.Get(ctx, "unknown://db/test", &log.Entry{})
-	if err == nil {
-		t.Error("possible to get a database with unknown:// scheme")
-	}
+	assert.Error(t, err)
 }
 
 func TestGetUnparsableScheme(t *testing.T) {
 	ctx := context.Background()
 	_, err := database.Get(ctx, "://", &log.Entry{})
-	if err == nil {
-		t.Error("possible to get a database with an unparsable scheme")
-	}
+	assert.Error(t, err)
 }

--- a/internal/responses/responses_test.go
+++ b/internal/responses/responses_test.go
@@ -16,47 +16,26 @@
 package responses
 
 import (
-	"encoding/json"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Test that RespondWithJSON writes the correct HTTP code, message and adds a content type header.
 func TestRespondWithJSON(t *testing.T) {
 	responseRecorder := httptest.NewRecorder()
 	RespondWithJSON(responseRecorder, 200, map[string]string{"hello": "world"})
-	if responseRecorder.Header().Get("Content-Type") != "application/json" {
-		t.Error("content type is not set to application/json")
-	}
-	if responseRecorder.Result().StatusCode != 200 {
-		t.Error("status code was not properly set")
-	}
-	var jsonBody map[string]string
-	err := json.Unmarshal(responseRecorder.Body.Bytes(), &jsonBody)
-	if err != nil {
-		t.Error(err)
-	}
-	if jsonBody["hello"] != "world" {
-		t.Error("body was set incorrectly")
-	}
+	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
+	assert.Equal(t, 200, responseRecorder.Result().StatusCode)
+	assert.JSONEq(t, `{"hello": "world"}`, responseRecorder.Body.String())
 }
 
 // Test that RespondWithError writes the correct HTTP code, message and adds a content type header.
 func TestRespondWithError(t *testing.T) {
 	responseRecorder := httptest.NewRecorder()
 	RespondWithError(responseRecorder, 400, "failure")
-	if responseRecorder.Header().Get("Content-Type") != "application/json" {
-		t.Error("content type is not set to application/json")
-	}
-	if responseRecorder.Result().StatusCode != 400 {
-		t.Error("status code was not properly set")
-	}
-	var jsonBody map[string]string
-	err := json.Unmarshal(responseRecorder.Body.Bytes(), &jsonBody)
-	if err != nil {
-		t.Error(err)
-	}
-	if jsonBody["error"] != "failure" {
-		t.Error("body was set incorrectly")
-	}
+	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
+	assert.Equal(t, 400, responseRecorder.Result().StatusCode)
+	assert.JSONEq(t, `{"error": "failure"}`, responseRecorder.Body.String())
 }

--- a/pkg/v1alpha1/api/api_test.go
+++ b/pkg/v1alpha1/api/api_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/eiffel-community/eiffel-goer/internal/schema"
 	"github.com/eiffel-community/eiffel-goer/pkg/application"
@@ -63,9 +64,7 @@ func TestRoutes(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			ctx := context.Background()
 			app, err := application.Get(ctx, mockCfg, log.NewEntry(log.New()))
-			if err != nil {
-				t.Error(err)
-			}
+			assert.NoError(t, err)
 			app.Database = mockDB
 			app.LoadV1Alpha1Routes()
 
@@ -73,10 +72,7 @@ func TestRoutes(t *testing.T) {
 			request := httptest.NewRequest(testCase.httpMethod, testCase.url, nil)
 
 			app.Router.ServeHTTP(responseRecorder, request)
-			expectedStatusCode := testCase.statusCode
-			if responseRecorder.Code != expectedStatusCode {
-				t.Errorf("Want status '%d' for %q, got '%d'", expectedStatusCode, testCase.url, responseRecorder.Code)
-			}
+			assert.Equal(t, testCase.statusCode, responseRecorder.Code)
 		})
 	}
 }

--- a/pkg/v1alpha1/handlers/events/events_test.go
+++ b/pkg/v1alpha1/handlers/events/events_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/eiffel-community/eiffel-goer/internal/schema"
 	"github.com/eiffel-community/eiffel-goer/test/mock_config"
@@ -92,18 +93,10 @@ func TestEvents(t *testing.T) {
 			responseRecorder := httptest.NewRecorder()
 			handler.ServeHTTP(responseRecorder, testCase.request)
 
-			expectedStatusCode := testCase.statusCode
-			if responseRecorder.Code != expectedStatusCode {
-				t.Errorf("Want status '%d' for %q, got '%d'", expectedStatusCode, testCase.request.URL.String(), responseRecorder.Code)
-			}
+			assert.Equalf(t, testCase.statusCode, responseRecorder.Code, "Input URL: %s", testCase.request.URL)
 			eventFromResponse := schema.EiffelEvent{}
-			err = json.Unmarshal(responseRecorder.Body.Bytes(), &eventFromResponse)
-			if err != nil {
-				t.Error(err)
-			}
-			if eventFromResponse.Meta.ID != testCase.eventID {
-				t.Error("event returned with response is not the same as the one in DB")
-			}
+			assert.NoError(t, json.Unmarshal(responseRecorder.Body.Bytes(), &eventFromResponse))
+			assert.Equal(t, testCase.eventID, eventFromResponse.Meta.ID)
 		})
 	}
 }


### PR DESCRIPTION
### Applicable Issues
Fixes #5 

### Description of the Change
The [github.com/stretchr/testify/assert](https://pkg.go.dev/github.com/stretchr/testify/assert) package contains many convenience functions for performing assertions during tests, making tests quicker to write and easier on the eyes.

In most cases no explicit assertion message is being supplied since the output generated by the package provides sufficient context.

### Alternate Designs
None.

### Benefits
Tests become less verbose, to the benefit of both readers and writers of tests.

### Possible Drawbacks
In some cases the automatically generated failure messages might contain slightly less information than the previous hand-written ones.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
