### PR TITLE
Upgrade Go to 1.17 and start using testing.T.Setenv

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.16.3"
+          go-version: "1.17.3"
 
       - name: Build and test
         run: make build check tidy check-dirty

--- a/deploy/goer/Dockerfile
+++ b/deploy/goer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine AS build
+FROM golang:1.17.3-alpine AS build
 WORKDIR /tmp/goer
 COPY . .
 RUN go build -o ./bin/goer ./cmd/goer

--- a/deploy/goer/Dockerfile.dev
+++ b/deploy/goer/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.16.3
+FROM golang:1.17.3
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eiffel-community/eiffel-goer
 
-go 1.16
+go 1.17
 
 require (
 	github.com/golang/mock v1.4.4
@@ -10,8 +10,25 @@ require (
 	github.com/snowzach/rotatefilehook v0.0.0-20180327172521-2f64f265f58c
 	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.7.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/klauspost/compress v1.9.5 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.0.2 // indirect
+	github.com/xdg-go/stringprep v1.0.2 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
+	golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 // indirect
+	golang.org/x/text v0.3.5 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,7 +16,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,10 +27,10 @@ func TestGet(t *testing.T) {
 	connectionString := "connection string"
 	logLevel := "DEBUG"
 	logFilePath := "path/to/a/file"
-	os.Setenv("CONNECTION_STRING", connectionString)
-	os.Setenv("API_PORT", port)
-	os.Setenv("LOGLEVEL", logLevel)
-	os.Setenv("LOG_FILE_PATH", logFilePath)
+	t.Setenv("CONNECTION_STRING", connectionString)
+	t.Setenv("API_PORT", port)
+	t.Setenv("LOGLEVEL", logLevel)
+	t.Setenv("LOG_FILE_PATH", logFilePath)
 
 	cfg, ok := Get().(*Cfg)
 	assert.Truef(t, ok, "cfg returned from get is not a config interface")


### PR DESCRIPTION
### Applicable Issues
Fixes #26

### Description of the Change
One of the tests set various environment variables with os.Setenv, but let's use testing.T.Setenv instead to get the original environment restored automatically and not risk flaky tests (flaky for _that_ reason anyway). This required us to bump the Go version to 1.17 in go.mod and a few other places. Go 1.17 introduced a slightly different format for go.mod (indirect dependencies in a separate `require` block) so that file was adjusted accordingly.

### Alternate Designs
None.

### Benefits
Decreased risk of flaky tests or tests that fail or succeed unexpectedly.

### Possible Drawbacks
None, unless one for some reason wants the source code to be compatible with Go 1.16.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
