### PR TITLE
Build binary with make in the Docker build; build image in GH workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,3 +20,21 @@ jobs:
 
       - name: Build and test
         run: make build check tidy check-dirty
+
+  build-docker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          # We need to specify the context explicitly so the action doesn't
+          # grab the source straight from the git. That's not a problem in
+          # itself but the .git directory (needed by govvv) won't be available.
+          context: .
+          file: deploy/goer/Dockerfile
+          pull: true

--- a/deploy/goer/Dockerfile
+++ b/deploy/goer/Dockerfile
@@ -1,7 +1,10 @@
 FROM golang:1.17.3-alpine AS build
+
+RUN apk update && apk add --no-cache git make
+
 WORKDIR /tmp/goer
 COPY . .
-RUN go build -o ./bin/goer ./cmd/goer
+RUN make build
 
 FROM alpine:3.13.5
 ENTRYPOINT ["/app/goer"]


### PR DESCRIPTION
### Applicable Issues
Fixes #18

### Description of the Change
Since we have various code generation stuff going on in the makefile we're better off using make to building during the Docker image build. This required installing a few additional packages.

To make sure we don't accidentally break the Docker image build again we add an image build step to the workflow that runs for commits and pull requests.

See https://github.com/magnusbaeck/eiffel-goer/actions/runs/1818517019 for an example workflow run.

### Alternate Designs
None.

### Benefits
Working Docker image build and verification so it keeps on working.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
