### PR TITLE
internal/query: Perform URL decoding on values

### DIFF
--- a/internal/query/query.peg
+++ b/internal/query/query.peg
@@ -78,7 +78,11 @@ Op <- ( "!=" / "%3C=" / "%3E=" / "%3C" / "%3E" / "=" ) {
 }
 
 Value <- [^&]* {
-    return string(c.text), nil
+    s, err := url.QueryUnescape(string(c.text))
+    if err != nil {
+        return nil, err
+    }
+    return s, nil
 }
 
 EOF <- !.


### PR DESCRIPTION
### Applicable Issues
Fixes #35

### Description of the Change
Unless we URL decode the values in queries like

    /events?data.identity=pkg%3Ageneric%2Ffoo%401.0.0

before including the value in a MongoDB filter the user is obviously going to get very disappointed.

### Alternate Designs
None.

### Benefits
It'll be possible to pose queries that include characters that need to be URL-escaped (e.g. purls with qualifiers).

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
