### PR TITLE
Fix a bug when providing an empty query string

### DIFF
--- a/internal/database/drivers/mongodb/mongodb.go
+++ b/internal/database/drivers/mongodb/mongodb.go
@@ -193,9 +193,6 @@ func (m *Database) GetEvents(ctx context.Context, request requests.MultipleEvent
 			numberOfDocuments += count
 		}
 		allEvents = append(allEvents, events...)
-		if len(allEvents) >= int(request.PageSize) {
-			break
-		}
 	}
 	return allEvents, numberOfDocuments, nil
 }

--- a/internal/database/drivers/mongodb/mongodb.go
+++ b/internal/database/drivers/mongodb/mongodb.go
@@ -167,7 +167,7 @@ func (m *Database) GetEvents(ctx context.Context, request requests.MultipleEvent
 	}
 
 	m.logger.Debugf("fetching events from %d collections", len(collections))
-	allEvents := make([]drivers.EiffelEvent, 0)
+	allEvents := make([]drivers.EiffelEvent, 0, request.PageSize)
 	var numberOfDocuments int64
 	for _, collection := range collections {
 		var events []drivers.EiffelEvent

--- a/internal/database/drivers/mongodb/mongodb.go
+++ b/internal/database/drivers/mongodb/mongodb.go
@@ -193,6 +193,9 @@ func (m *Database) GetEvents(ctx context.Context, request requests.MultipleEvent
 			numberOfDocuments += count
 		}
 		allEvents = append(allEvents, events...)
+		if len(allEvents) >= int(request.PageSize) {
+			break
+		}
 	}
 	return allEvents, numberOfDocuments, nil
 }

--- a/internal/database/drivers/mongodb/mongodb.go
+++ b/internal/database/drivers/mongodb/mongodb.go
@@ -172,14 +172,14 @@ func (m *Database) GetEvents(ctx context.Context, request requests.MultipleEvent
 	for _, collection := range collections {
 		var events []drivers.EiffelEvent
 		limit := request.PageSize - int32(len(allEvents))
-		findOptions := options.Find().
-			SetProjection(bson.M{"_id": 0}).
-			SetSkip(int64((request.PageNo - 1) * request.PageSize)).
-			SetLimit(int64(limit))
 
 		col := m.database.Collection(collection)
 		if limit > 0 {
-			cursor, err := col.Find(ctx, filter, findOptions)
+			cursor, err := col.Find(ctx, filter, options.Find().
+				SetProjection(bson.M{"_id": 0}).
+				SetSkip(int64((request.PageNo-1)*request.PageSize)).
+				SetLimit(int64(limit)),
+			)
 
 			if err != nil {
 				continue

--- a/internal/database/drivers/mongodb/mongodb.go
+++ b/internal/database/drivers/mongodb/mongodb.go
@@ -167,7 +167,7 @@ func (m *Database) GetEvents(ctx context.Context, request requests.MultipleEvent
 	}
 
 	m.logger.Debugf("fetching events from %d collections", len(collections))
-	var allEvents []drivers.EiffelEvent
+	allEvents := make([]drivers.EiffelEvent, 0)
 	var numberOfDocuments int64
 	for _, collection := range collections {
 		var events []drivers.EiffelEvent

--- a/pkg/v1alpha1/handlers/events/events.go
+++ b/pkg/v1alpha1/handlers/events/events.go
@@ -142,10 +142,5 @@ func (h *EventHandler) ReadAll(w http.ResponseWriter, r *http.Request) {
 		totalNumberItems,
 		events,
 	}
-	// This is required in order to get the response key 'items' to be an
-	// empty JSON array instead of null when no events are returned.
-	if len(events) == 0 {
-		response.Items = make([]drivers.EiffelEvent, 0)
-	}
 	responses.RespondWithJSON(w, http.StatusOK, response)
 }

--- a/pkg/v1alpha1/handlers/events/events.go
+++ b/pkg/v1alpha1/handlers/events/events.go
@@ -82,6 +82,9 @@ type multiResponse struct {
 
 // buildConditions takes a raw URL query, parses out all conditions and removes ignoreKeys.
 func buildConditions(rawQuery string, ignoreKeys map[string]struct{}) ([]query.Condition, error) {
+	if rawQuery == "" {
+		return nil, nil
+	}
 	res, err := query.Parse("nofile", []byte(rawQuery))
 	if err != nil {
 		return nil, err

--- a/pkg/v1alpha1/handlers/events/events.go
+++ b/pkg/v1alpha1/handlers/events/events.go
@@ -142,5 +142,10 @@ func (h *EventHandler) ReadAll(w http.ResponseWriter, r *http.Request) {
 		totalNumberItems,
 		events,
 	}
+	// This is required in order to get the reponse key 'items' to be an
+	// empty JSON array instead of null when no events are returned.
+	if len(events) == 0 {
+		response.Items = make([]drivers.EiffelEvent, 0)
+	}
 	responses.RespondWithJSON(w, http.StatusOK, response)
 }

--- a/pkg/v1alpha1/handlers/events/events.go
+++ b/pkg/v1alpha1/handlers/events/events.go
@@ -121,6 +121,10 @@ func (h *EventHandler) ReadAll(w http.ResponseWriter, r *http.Request) {
 		responses.RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if request.PageSize < 0 {
+		responses.RespondWithError(w, http.StatusBadRequest, "PageSize must be a positive integer")
+		return
+	}
 
 	ignoreKeys := getTags("schema", &request)
 	conditions, err := buildConditions(r.URL.RawQuery, ignoreKeys)

--- a/pkg/v1alpha1/handlers/events/events.go
+++ b/pkg/v1alpha1/handlers/events/events.go
@@ -142,7 +142,7 @@ func (h *EventHandler) ReadAll(w http.ResponseWriter, r *http.Request) {
 		totalNumberItems,
 		events,
 	}
-	// This is required in order to get the reponse key 'items' to be an
+	// This is required in order to get the response key 'items' to be an
 	// empty JSON array instead of null when no events are returned.
 	if len(events) == 0 {
 		response.Items = make([]drivers.EiffelEvent, 0)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
Fixes: #21 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Make it possible to request with an empty query string

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
In this version we will retrieve events from collections until `pageSize` has been reached. This does not guarantee that you will get the latest `pageSize` number of events. If we were to sort these events in terms of timestamp sent, then that would be costly on both GoER as well as the event repository since we are separating event types in different collections.

### Benefits
<!-- What benefits will be realized by the change? -->
This works against the API schema and it will not cost too many resources.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Users might expect to see the 'latest' events and not a 'random' selection of them. However I believe that a generic 'get-latest-events' request is not a normal use-case.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
