### PR TITLE
Make sure to return 404 when no events are found

### DIFF
--- a/internal/responses/responses.go
+++ b/internal/responses/responses.go
@@ -32,6 +32,6 @@ func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 // RespondWithError writes a response with an error message and status code to the HTTP ResponseWriter.
 func RespondWithError(w http.ResponseWriter, code int, message string) {
 	w.WriteHeader(code)
-	w.Header().Set("Content-Type", "text/plan; charset=utf-8")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	_, _ = w.Write([]byte(message))
 }

--- a/internal/responses/responses.go
+++ b/internal/responses/responses.go
@@ -32,5 +32,6 @@ func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 // RespondWithError writes a response with an error message and status code to the HTTP ResponseWriter.
 func RespondWithError(w http.ResponseWriter, code int, message string) {
 	w.WriteHeader(code)
+	w.Header().Set("Content-Type", "text/plan; charset=utf-8")
 	_, _ = w.Write([]byte(message))
 }

--- a/internal/responses/responses.go
+++ b/internal/responses/responses.go
@@ -29,7 +29,8 @@ func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 	_, _ = w.Write(response)
 }
 
-// RespondWithError writes a JSON response with an error message and status code to the HTTP ResponseWriter.
+// RespondWithError writes a response with an error message and status code to the HTTP ResponseWriter.
 func RespondWithError(w http.ResponseWriter, code int, message string) {
-	RespondWithJSON(w, code, map[string]string{"error": message})
+	w.WriteHeader(code)
+	_, _ = w.Write([]byte(message))
 }

--- a/internal/responses/responses_test.go
+++ b/internal/responses/responses_test.go
@@ -34,8 +34,7 @@ func TestRespondWithJSON(t *testing.T) {
 // Test that RespondWithError writes the correct HTTP code, message and adds a content type header.
 func TestRespondWithError(t *testing.T) {
 	responseRecorder := httptest.NewRecorder()
-	RespondWithError(responseRecorder, 400, "failure")
-	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
+	RespondWithError(responseRecorder, 400, "Bad Request")
 	assert.Equal(t, 400, responseRecorder.Result().StatusCode)
-	assert.JSONEq(t, `{"error": "failure"}`, responseRecorder.Body.String())
+	assert.Equal(t, "Bad Request", responseRecorder.Body.String())
 }


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
Fixes: #34 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
There will now be a 404 if we do not find any events on a query. I also cleaned up so that we never return JSON payloads on errors.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I decided to actually send a response payload in the form of the HTTP error status message. This, in my opinion, makes it more clear than letting the browser scream "PAGE NOT FOUND!" when you don't find any events.

### Benefits
<!-- What benefits will be realized by the change? -->
We will follow the API specification and the risk of returning internal information to the users is reduced.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None that I can think of.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
