### PR TITLE
Set labels on the Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ stop:
 # Build a docker using the production Dockerfile
 .PHONY: docker
 docker:
-	docker build -t $(DOCKER_REGISTRY)/$(DEPLOY):$(RELEASE_VERSION) -f ./deploy/$(DEPLOY)/Dockerfile .
+	docker build --build-arg revision=$(RELEASE_VERSION) -t $(DOCKER_REGISTRY)/$(DEPLOY):$(RELEASE_VERSION) -f ./deploy/$(DEPLOY)/Dockerfile .
 
 .PHONY: push
 push:

--- a/deploy/goer/Dockerfile
+++ b/deploy/goer/Dockerfile
@@ -9,3 +9,9 @@ RUN make build
 FROM alpine:3.13.5
 ENTRYPOINT ["/app/goer"]
 COPY --from=build /tmp/goer/bin/goer /app/goer
+
+ARG revision
+LABEL com.datadoghq.tags.version="${revision}" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.source="https://github.com/eiffel-community/eiffel-goer"


### PR DESCRIPTION
### Applicable Issues
Fixes #45 

### Description of the Change
To improve traceability of our Docker image and add other useful metadata let's set a few OCI labels, plus a Datadog label to make life easier for users of Datadog without impacting others.

There no foolproof way of detecting the repository we're building from so the repository URL is unfortunately hardcoded.

### Alternate Designs
Considered using e.g. `git remote get-url origin` to obtain the repository URL to put in the org.opencontainers.image.source label, but there are just so many ways that could result in an undesirable URL.

### Benefits
More metadata about the image is made available for e.g. observability tools.

### Possible Drawbacks
The hardcoded repository URL will result in bad label values if someone makes local changes to a fork. However, if you're forking this repository and making changes you might as well update the URL in the dockerfile too.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
